### PR TITLE
feat: allow type-less <button>s in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -278,6 +278,8 @@ module.exports = {
       rules: {
         'react/jsx-no-bind': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
+        'react/button-has-type': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -279,7 +279,6 @@ module.exports = {
         'react/jsx-no-bind': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         'react/button-has-type': 'off',
-        '@typescript-eslint/no-explicit-any': 'off',
       },
     },
   ],


### PR DESCRIPTION
- type-less `<button>`s are useful in enzyme containsAnyMatchingElement pattern elements (eg when searching a render tree for "any button with class `foo`")
- explicit any is useful when providing a partial props object to an element when it is not important to specify all of the props