### PR TITLE
feat: ensure readable variable names

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -212,8 +212,69 @@ module.exports = {
     'unicorn/no-useless-undefined': 'off', // conflicts with TypeScript
     'unicorn/prefer-number-properties': 'off',
     'unicorn/custom-error-definition': 'off', // false positives: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/753
-    'unicorn/prevent-abbreviations': 'off',
     'unicorn/no-nested-ternary': 'off', // if-elseif-else ternaries are commonly needed in JSX and formatted well by Prettier
+    'id-length': [
+      'error',
+      {
+        min: 3,
+        properties: 'never',
+        exceptions: [
+          // valid
+          'to',
+          'as',
+          'id',
+          // NodeJS standard library
+          'fs',
+          // conventionally used for import * as H from 'history' to not conflict with the global history
+          'H',
+          // allow `distinctUntilChanged((a, b) => isEqual(a, b))`,
+          // which is extremely common and necessary to maintain type safety.
+          'a',
+          'b',
+          // caught by prevent-abbreviations below, avoid double-flagging
+          'e',
+          'i',
+          'ch',
+        ],
+      },
+    ],
+    'unicorn/prevent-abbreviations': [
+      'error',
+      {
+        checkShorthandImports: false,
+        replacements: {
+          e: {
+            event: true,
+            error: true,
+            editor: true,
+            end: true, // as in e2e
+          },
+          i: { index: true },
+          idx: { index: true },
+          ch: { character: true },
+          j2d: { goToDefinition: true },
+          pos: { position: true },
+          ext: { extension: true },
+          expr: { expression: true },
+          sub: { subscription: true },
+          obs: { observable: true, observer: true },
+          // When saving a document in a variable, we usually don't mean the the global document,
+          // but an extension API text document. Avoid shadowing suffixes.
+          doc: { document: false, textDocument: true },
+          // Never needed in our codebase, better to have an autofix for directory
+          dir: { direction: false },
+          // The meaning of rev vs ref is a common source of confusion.
+          // Spelling it out makes it clear.
+          rev: { revision: true },
+          // Allow since it's a React term
+          props: false,
+        },
+        whitelist: {
+          args: true, // arguments is special
+          fs: true, // NodeJS standard library
+        },
+      },
+    ],
   },
   overrides: [
     {
@@ -332,6 +393,8 @@ module.exports = {
         'no-var': 'off',
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/no-use-before-define': 'off',
+        'unicorn/prevent-abbreviations': 'off',
+        'id-length': 'off',
       },
     },
     {


### PR DESCRIPTION
**We favor readable variable names over abbreviations in our TypeScript code.** (e.g. very recently pointed out in https://github.com/sourcegraph/sourcegraph/pull/11033#discussion_r432477033).

There are multiple reasons for this:

- Using complete words results in more readable code.
- Not everyone knows all your abbreviations. They may seem obvious to you, but are often not to future editors or reviewers.
- Code is written only once, but read many times.
- Abbreviations are an accessibility problem. Try going over a codebase that conventionally uses abbreviations for variable names with a screen reader - the screen reader doesn't know what the abbreviation stands for, so it cannot pronounce it the way a not-visually-impaired developer recognizing the meaning would. See also https://about.sourcegraph.com/handbook/engineering/languages/go#use-pronounceable-names
  - Especially since we are open source, we shouldn't wait to do this until we have a visually-impaired teammate.
- TypeScript has great autocompletion across the board, so writing a longer variable name is a one-time cost (references can get autocompleted)
- Variable names often "roam" into property names in TypeScript using property shorthands. Properties more commonly don't use abbreviations, so abbreviating variable names means shorthands can't be used, which leads to repetition and a less clear connection between a variable and the property it will be assigned to.
- Specifically at Sourcegraph we all have some internalized abbreviations that are obvious to us because we used them for years, but not obvious at all to externals or new hires. For example `j2d` for "jump to definition" or extremely similar abbreviations for things that have nuanced differences, like `rev` vs `ref` (git revision vs git reference). The prevalence of such confusing abbreviations in our codebase [sometimes even leads us to design **public** API (e.g. settings) that conflate the meaning](https://github.com/sourcegraph/sourcegraph/pull/10686#discussion_r425285730). 

At the same time, bikeshedding about naming in PRs is not a good use of anyone's time and doesn't scale. Meanwhile, we also sometimes have Go engineers contribute code to our TypeScript codebase, who _are_ used to abbreviating variable names by convention.

The ideal solution: Write abbreviations and have them automatically be expanded to full words on save, or if not possible, at least flagged as early as possible in the editor, or in CI as a last defense (but not by manual, human code review). Of course you are also still welcome and encouraged to write non-abbreviated code from the start.

Here are some recordings of what this workflow looks like:

![2020-06-01 11 56 56](https://user-images.githubusercontent.com/10532611/83400739-a6e36900-a403-11ea-9e48-cb0d1eb93235.gif)

![2020-06-01 11 52 29](https://user-images.githubusercontent.com/10532611/83400742-a945c300-a403-11ea-9507-2f30f66e6eb3.gif)

I went over our codebase with this rule and identified the most common abbreviations to add them to the already large default dictionary. As always there are some exceptions for various reasons like reserved keywords in JS, but it works really well for the vast majority of cases.

Rule documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prevent-abbreviations.md