### PR TITLE
fix: disable no-use-before-define

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -376,7 +376,9 @@ module.exports = {
             ignoreRestSiblings: true,
           },
         ],
-        '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
+        // no-use-before-define goes against the top-to-bottom rule and TypeScript protects against most temporal deadzone bugs.
+        // https://dzone.com/articles/the-stepdown-rule
+        '@typescript-eslint/no-use-before-define': 'off',
         '@typescript-eslint/no-useless-constructor': 'error',
         '@typescript-eslint/no-var-requires': 'error',
         '@typescript-eslint/prefer-as-const': 'error',
@@ -419,7 +421,6 @@ module.exports = {
       rules: {
         'no-var': 'off',
         '@typescript-eslint/explicit-member-accessibility': 'off',
-        '@typescript-eslint/no-use-before-define': 'off',
         'unicorn/prevent-abbreviations': 'off',
         'id-length': 'off',
       },


### PR DESCRIPTION
This rule has gotten more strict (catch more previous false negatives) and it made me question its value. I saw that it caused a lot more failures in our codebase in https://github.com/sourcegraph/sourcegraph/pull/14602. It seems that intuitively we like to write functions in call tree order, i.e. entry point first, inner functions last. This is exactly the opposite of what this rule enforces: all inner functions must be defined before they are used, i.e. the out-most function comes last in each file. The rule is supposed to protect against the temporal deadzone of `const`, but TypeScript also protects against obvious temporal deadzone problems (while allowing references from inside functions, which is fine as long they are not immediately called, which is rare). I propose to disable this rule as it's just extra work to obey to it for code that we seemingly intuitively find less readable (else we wouldn't write so much work intuitively in the reverse order).