### PR TITLE
Add import/no-default-export rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -140,6 +140,7 @@ module.exports = {
     'import/no-dynamic-require': 'error',
     'import/no-useless-path-segments': 'error',
     'import/no-duplicates': 'error',
+    'import/no-default-export': 'error',
 
     // JSDoc
     'jsdoc/require-returns': 'off',
@@ -423,6 +424,7 @@ module.exports = {
         '@typescript-eslint/explicit-member-accessibility': 'off',
         'unicorn/prevent-abbreviations': 'off',
         'id-length': 'off',
+        'import/no-default-export': 'off',
       },
     },
     {


### PR DESCRIPTION
Thoughts on this?
- We're already discouraging their usage in some of our [documentation](https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/background-information/web/web_app.md#code-splitting)
- Our usage of default exports is fairly low and this will help catch issues before they hit PR

[Further reading on why default exports are bad](https://basarat.gitbook.io/typescript/main-1/defaultisbad)