### PR TITLE
feat: disable react/jsx-no-bind rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -187,7 +187,7 @@ module.exports = {
     'react/jsx-curly-brace-presence': 'error',
     'react/jsx-fragments': ['error', 'syntax'],
     'react/jsx-key': 'error',
-    'react/jsx-no-bind': ['error', { ignoreRefs: true, ignoreDOMComponents: true }],
+    'react/jsx-no-bind': 'off',
     'react/jsx-no-comment-textnodes': 'error',
     'react/jsx-no-target-blank': 'error',
     'react/no-access-state-in-setstate': 'error',


### PR DESCRIPTION
### Changes

- Disabled [react/jsx-no-bind](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) rule.

Only known performance issues need to be solved in a way this rule proposes.
Good article on the topic: https://kentcdodds.com/blog/usememo-and-usecallback#why-is-usecallback-worse

Context [thread](https://github.com/sourcegraph/sourcegraph/pull/20302#discussion_r621073632).