### PR TITLE
feat: add unused-imports plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
   globals: {
     globalThis: false, // false means not writable
   },
-  plugins: ['ban', 'jsdoc', 'react', 'react-hooks', 'etc', 'rxjs', 'jest-dom', 'jsx-a11y'],
+  plugins: ['ban', 'jsdoc', 'react', 'react-hooks', 'etc', 'rxjs', 'jest-dom', 'jsx-a11y', 'unused-imports'],
   settings: {
     react: {
       version: 'detect',
@@ -314,6 +314,9 @@ module.exports = {
         },
       },
     ],
+
+    'unused-imports/no-unused-imports': 'error',
+    'unused-imports/no-unused-vars': 'off',
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react": "^7.21.4",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-rxjs": "^2.1.5",
-    "eslint-plugin-unicorn": "^21.0.0"
+    "eslint-plugin-unicorn": "^21.0.0",
+    "eslint-plugin-unused-imports": "^1.1.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,6 +2006,18 @@ eslint-plugin-unicorn@^21.0.0:
     safe-regex "^2.1.1"
     semver "^7.3.2"
 
+eslint-plugin-unused-imports@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.5.tgz#a2b992ef0faf6c6c75c3815cc47bde76739513c2"
+  integrity sha512-TeV8l8zkLQrq9LBeYFCQmYVIXMjfHgdRQLw7dEZp4ZB3PeR10Y5Uif11heCsHRmhdRIYMoewr1d9ouUHLbLHew==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
Adds [eslint-plugin-unused-imports](https://github.com/sweepline/eslint-plugin-unused-imports), which identifies and reports unused imports just like TS already does, but has one distinct advantage: autofix!! Here's a recording demonstration where my editor runs `eslint --fix` on save:

https://user-images.githubusercontent.com/8942601/141856619-e97be611-2dd6-4090-9491-9662cd349969.mov

It's SO easy to miss an unused import locally because they hide way up at the top of your file where you're not doing actual work. If I had a dollar for every time I've amended a commit or pushed the commit `"Remove unused import"` only after I realized CI failed... 🤦‍♀️ For those of us with setups that run eslint autofix on save, this is a lifesaver. 