### PR TITLE
feat: add scss and react  support in import order eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,8 +154,19 @@ module.exports = {
         },
         pathGroups: [
           {
+            pattern: 'react',
+            group: 'external',
+            position: 'before',
+          },
+          {
             pattern: '@sourcegraph/**',
             group: 'external',
+            position: 'after',
+          },
+          {
+            pattern: '*.scss',
+            group: 'index',
+            patternOptions: { matchBase: true },
             position: 'after',
           },
         ],

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,14 @@
+golang 1.17.5
+nodejs 16.7.0
+yarn 1.22.17
+fd 7.4.0
+shfmt 3.2.0
+shellcheck 0.7.1
+kubectl 1.21.7
+github-cli 2.0.0
+packer 1.7.10
+trivy 0.20.0
+kustomize 4.0.5
+awscli 2.4.7
+python system
+rust 1.58.0

--- a/check_dependent.sh
+++ b/check_dependent.sh
@@ -8,6 +8,7 @@ CONFIG_DIR=$(pwd)
 CLONE_DIR=$(mktemp -d)
 git clone --depth 1 https://github.com/sourcegraph/sourcegraph "$CLONE_DIR"
 cd "$CLONE_DIR"
+mkdir -p annotations
 echo "--- install nodejs"
 asdf install
 echo "--- yarn"

--- a/package.json
+++ b/package.json
@@ -11,10 +11,6 @@
     ".eslintrc.js"
   ],
   "main": ".eslintrc.js",
-  "engines": {
-    "node": "^v16.7.0",
-    "yarn": "^1.22.4"
-  },
   "scripts": {
     "semantic-release": "semantic-release",
     "prettier": "prettier '**/*.{js?(on),ts?(x),scss,md,yml}' --write --list-different",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     ".eslintrc.js"
   ],
   "main": ".eslintrc.js",
+  "engines": {
+    "node": "^v16.7.0",
+    "yarn": "^1.22.4"
+  },
   "scripts": {
     "semantic-release": "semantic-release",
     "prettier": "prettier '**/*.{js?(on),ts?(x),scss,md,yml}' --write --list-different",


### PR DESCRIPTION
## Background 

Prior to this PR, our current eslint config allowed us to have the following imports order
```tsx
import { voronoi } from '@visx/voronoi'
import { noop } from 'lodash'
import React, { ReactElement, useMemo, useRef, useState } from 'react'

import styleHello from './world-styles'
import styles from './local.module.scss'
import hello from './world'
```

As you can see the syles imports and react imports are mixed with other group packages. Which makes the import section a bit confusing.

Since in react component React is the main import it should be the first import in the file. 
Since styles import has the biggest specific to the component it should be the last import in the file. 

```tsx
import React, { ReactElement, useMemo, useRef, useState } from 'react'

import { voronoi } from '@visx/voronoi'
import { noop } from 'lodash'

import styleHello from './world-styles'
import hello from './world'

import styles from './local.module.scss'
```
