### PR TITLE
fix: eslint command in the check dependent script

### DIFF
--- a/check_dependent.sh
+++ b/check_dependent.sh
@@ -24,4 +24,4 @@ yarn generate
 echo "--- build-ts"
 yarn build-ts
 echo "--- eslint"
-yarn all:eslint
+yarn lint:js:all


### PR DESCRIPTION
## Context

The ESLint command [was changed](https://github.com/sourcegraph/sourcegraph/commit/868472f43e800deef84d3194aa8d3f8c2732f9bd#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16) in the main Sourcegraph repo.