### PR TITLE
Fix asdf installation

### DIFF
--- a/buildkite.yml
+++ b/buildkite.yml
@@ -3,15 +3,25 @@ env:
   # Bump Node.js memory to prevent OOM crashes
   NODE_OPTIONS: --max_old_space_size=4096
 
+template:
+  - &asdf_cache_plugin
+    https://github.com/sourcegraph/asdf-cache-buildkite-plugin.git#main:
+      bucket_name: 'sourcegraph_buildkite_cache'
+      region_name: 'us-central1'
+
 steps:
   - command: |-
       yarn
       yarn prettier-check
     label: ':prettier:'
+    plugins:
+      - *asdf_cache_plugin
 
   - command: ./check_dependent.sh
     label: ':eslint:'
     branches: '!master'
+    plugins:
+      - *asdf_cache_plugin
 
   - wait
 
@@ -22,3 +32,5 @@ steps:
     label: ':npm:'
     concurrency: 1
     concurrency_group: release
+    plugins:
+      - *asdf_cache_plugin

--- a/check_dependent.sh
+++ b/check_dependent.sh
@@ -9,8 +9,6 @@ CLONE_DIR=$(mktemp -d)
 git clone --depth 1 https://github.com/sourcegraph/sourcegraph "$CLONE_DIR"
 cd "$CLONE_DIR"
 mkdir -p annotations
-echo "--- install nodejs"
-asdf install
 echo "--- yarn"
 yarn --frozen-lockfile
 echo "--- yarn add"


### PR DESCRIPTION
Hey folks, here's a fix for the the pipeline, the step that runs `asdf install` was missing. As we've recently extracted it into a plugin, that's pretty straightforward and you get some caching for free along the way. 

There is still a failure on the last step, but I think that's more related to your stuff. 