### PR TITLE
Disable unicorn/number-literal-case

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -335,6 +335,7 @@ module.exports = {
     // New rules added to unicorn
     'unicorn/no-array-reduce': 'off',
     'unicorn/no-array-callback-reference': 'off',
+    'unicorn/number-literal-case': 'off',
     'unicorn/numeric-separators-style': 'off',
     'unicorn/prefer-switch': 'off',
     'unicorn/prefer-spread': 'off',


### PR DESCRIPTION
This PR disables [unicorn/number-literal-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v42.0.0/docs/rules/number-literal-case.md) since it interferes with our prettier config that forces lowercase values already. E.g.

```
0xFF
```

is changed to the following vie prettier:

```
0xff
```