### PR TITLE
feat: disable `jsdoc/check-indentation`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -174,12 +174,14 @@ module.exports = {
       },
     ],
 
-    // JSDoc
+    // 
+    
+    
     'jsdoc/require-returns': 'off',
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/require-param': 'off',
     'jsdoc/no-bad-blocks': 'error',
-    'jsdoc/check-indentation': 'error',
+    'jsdoc/check-indentation': 'off',
     'jsdoc/check-tag-names': [
       'error',
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -174,9 +174,7 @@ module.exports = {
       },
     ],
 
-    // 
-    
-    
+    // JSDoc
     'jsdoc/require-returns': 'off',
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/require-param': 'off',


### PR DESCRIPTION
The rule doesn't work as expected and is disabled https://sourcegraph.com/search?q=context%3Aglobal+repo%3Agithub.com%2Fsourcegraph%2Fsourcegraph%24+jsdoc%2Fcheck-indentation&patternType=standard&sm=1&groupBy=repo in the main repo.